### PR TITLE
Added explicit paths in README kubectl step.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
  <li> This will create an mvn repository for your project. You
       can check that locally on below path <b>.m2/repository/io/fabric8 </b></li>
  <li> After successful compilation of java-controller-runtime, go to the example folder</li>
- <li> Before running the operator, first create CRD and CR with command <b>kubectl apply -f "path of CRD and then CR"</b></li>
+ <li> Before running the operator, first create CRD and CR with command <b>kubectl create -f src/main/resources</b></li>
  <li> Then, run the operator first <b>mvn clean install</b> on example operator and then target
       folder has .jar file created for it.
- <li> Go to target folder and run the application with command <br>java -jar "Jar file Name"</li>
+ <li> Go to target folder and run the application with command <br>java -jar memcached-java-operator-1.0-SNAPSHOT-jar-with-dependencies.jar</li>
  <li> You can check the number of pods running with command <b>kubectl get pods</b>
    </ol>


### PR DESCRIPTION
Description: 
1. Replaced `apply` with `create` in kubectl step for creating resources.
2. Added actual jar name to run operator, to avoid confusion.
Closes: #3 